### PR TITLE
Fix for SIGABRT

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -101,10 +101,10 @@ int main() {
         while (linestream >> s) {
             // standardize string s
             if (!s.empty()) {
-                while (s[s.size() - 1] == ',' || s[s.size() - 1] == '.' || s[s.size() - 1] == '!' ||
+                while (!s.empty() && (s[s.size() - 1] == ',' || s[s.size() - 1] == '.' || s[s.size() - 1] == '!' ||
                        s[s.size() - 1] == '?' ||
                        s[s.size() - 1] == ';' || s[s.size() - 1] == ':' || s[s.size() - 1] == '"' ||
-                       s[s.size() - 1] == ')' || s[s.size() - 1] == '\'') {
+                       s[s.size() - 1] == ')' || s[s.size() - 1] == '\'')) {
                     s.pop_back();
                 }
                 while (s[0] == '"' || s[0] == '\'' || s[0] == '(') {
@@ -139,11 +139,11 @@ int main() {
         string s;
         while (linestream >> s) {
             if (!s.empty()) {
-                while (s[s.size() - 1] == ',' || s[s.size() - 1] == '.' || s[s.size() - 1] == '!' ||
+                while (!s.empty() && (s[s.size() - 1] == ',' || s[s.size() - 1] == '.' || s[s.size() - 1] == '!' ||
                        s[s.size() - 1] == '?' ||
                        s[s.size() - 1] == ';' || s[s.size() - 1] == ':' || s[s.size() - 1] == '"' ||
                        s[s.size() - 1] == '\'' || s[s.size() - 1] == '\n' || s[s.size() - 1] == '\t' ||
-                       s[s.size() - 1] == ')') {
+                       s[s.size() - 1] == ')')) {
                     s.pop_back();
                 }
                 while (s[0] == '"' || s[0] == '\'' || s[0] == '(') {


### PR DESCRIPTION
We noticed that the string indexing is causing some out-of-bounds errors now and then. The problem is that the code checks `!s.empty()` in the `while` condition, but then mutates the string using `s.pop_back()` so that `s` may be empty at that point. You may be able to reproduce this yourself using a file that only contains three characters: `" , "`  (space comma space). In any case, I have provided a patch that fixes the problem. 

Abort signature is below.
```
Using host libthread_db library "/lib64/libthread_db.so.1".
/builddir/build/BUILD/gcc-8.5.0-20210514/obj-aarch64-redhat-linux/aarch64-redhat-linux/libstdc++-v3/include/bits/basic_string.h:1071: std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::operator[](std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type) [with _CharT = char; _Traits = std::char_traits<char>; _Alloc = std::allocator<char>; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::reference = char&; std::__cxx11::basic_string<_CharT, _Traits, _Alloc>::size_type = long unsigned int]: Assertion '__pos <= size()' failed.

Program received signal SIGABRT, Aborted.
0x00004000003a69f4 in raise () from /lib64/libc.so.6
. where
#0  0x00004000003a69f4 in raise () from /lib64/libc.so.6
#1  0x00004000003909ec in abort () from /lib64/libc.so.6
#2  0x000040000011aa68 in std::__replacement_assert(char const*, int, char const*, char const*) () from /lib64/libstdc++.so.6
#3  0x0000400000195388 in std::__cxx11::basic_string<char, std::char_traits<char>, std::allocator<char> >::operator[](unsigned long) ()
   from /lib64/libstdc++.so.6
#4  0x00000000004020f0 in main (argc=<optimized out>, argv=<optimized out>) at compare/text_compare.cpp:89
```